### PR TITLE
chore: configure StyleCI to use MediaWiki coding standard preset

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -1,0 +1,2 @@
+php:
+  preset: mediawiki


### PR DESCRIPTION
Add .styleci.yml to enforce MediaWiki's own PHP coding style rather than the default PSR-2 preset, ensuring consistency with MediaWiki core and the broader extension ecosystem.